### PR TITLE
add code refactor to avoid code duplication

### DIFF
--- a/http.js
+++ b/http.js
@@ -123,7 +123,7 @@ Http.prototype.request = function(method, opts, callback) {
   finalOpts = _.omit(opts, ['data', 'url']);
   finalOpts.cookies = _.extend(this._cookieJar, finalOpts.cookies);
 
-  needle.request(method, url, data, finalOpts, function(err, res, body) {
+  needle.request(method, url, data, finalOpts, function (err, res, body) {
     _this._interceptResponse(err, res, body, url, data, makeRequest, callback);
   });
 

--- a/http.js
+++ b/http.js
@@ -15,20 +15,18 @@ _ = require('lodash');
 
 defaults = {
   follow_max: 0,
-  user_agent:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like ' +
-          'Gecko) Chrome/41.0.2272.76 Safari/537.36'
+  user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like '
+  + 'Gecko) Chrome/41.0.2272.76 Safari/537.36'
 };
 
 needle.defaults(defaults);
 
 /**
 * @class
-* @param {object} defaultCookies cookie jar for the class instance to be
-* initialized with, defaults
+* @param {object} defaultCookies cookie jar for the class instance to be initialized with, defaults
 * to a brand new cookie jar
 */
-function Http(defaultCookies) {
+function Http (defaultCookies) {
   /**
   * Cookie jar for the Http instance
   * @private
@@ -46,17 +44,15 @@ function Http(defaultCookies) {
 * Pushes a response object to the request log and responds to passed callback
 * @param {object} err Error object, is null if no error is present
 * @param {object} res Needle's response
-* @param {string} body Needle's response body only, is null if an error is
-* present
+* @param {string} body Needle's response body only, is null if an error is present
 * @param {function} callback Callback to be executed
 * @private
 */
-Http.prototype._interceptResponse =
-    function(err, res, body, url, data, makeRequest, callback) {
+Http.prototype._interceptResponse = function (err, res, body, url, data, makeRequest, callback) {
   var entry, resCookieString, _this, cb, noop, promiseResponse;
 
   _this = this;
-  noop = function() {};
+  noop = function () {};
   cb = callback || noop;
 
   if (err) {
@@ -65,10 +61,13 @@ Http.prototype._interceptResponse =
     return;
   }
 
-  promiseResponse = {res: res, body: body};
+  promiseResponse = {
+    res: res,
+    body: body
+  };
   resCookieString = '';
 
-  _.each(res.cookies, function(value, key) {
+  _.each(res.cookies, function (value, key) {
     // Update our cookie jar
     _this._cookieJar[key] = value;
 
@@ -102,7 +101,7 @@ Http.prototype._interceptResponse =
 * Pushes an entry to the class log
 * @param {object} logEntry entry that represents a unit of the log
 */
-Http.prototype._pushToLog = function(logEntry) {
+Http.prototype._pushToLog = function (logEntry) {
   this._log.push(logEntry);
 };
 
@@ -134,42 +133,42 @@ Http.prototype.request = function(method, opts, callback) {
 /**
 * Delegate to request's `del` method
 */
-Http.prototype.del = function(opts, callback) {
+Http.prototype.del = function (param1, param2) {
   return this.request('delete', opts, callback);
 };
 
 /**
 * Delegate to request's `get` method
 */
-Http.prototype.get = function(opts, callback) {
+Http.prototype.get = function (param1, param2) {
   return this.request('get', opts, callback);
 };
 
 /**
 * Delegate to request's `head` method
 */
-Http.prototype.head = function(opts, callback) {
+Http.prototype.head = function (param1, param2) {
   return this.request('head', opts, callback);
 };
 
 /**
 * Delegate to request's `patch` method
 */
-Http.prototype.patch = function(opts, callback) {
+Http.prototype.patch = function (param1, param2) {
   return this.request('patch', opts, callback);
 };
 
 /**
 * Delegate to request's `post` method
 */
-Http.prototype.post = function(opts, callback) {
+Http.prototype.post = function (param1, param2) {
   return this.request('post', opts, callback);
 };
 
 /**
 * Delegate to request's `put` method
 */
-Http.prototype.put = function(opts, callback) {
+Http.prototype.put = function (param1, param2) {
   return this.request('put', opts, callback);
 };
 
@@ -177,7 +176,7 @@ Http.prototype.put = function(opts, callback) {
 * Returns the current request log as an array
 * @return {array} current request log
 */
-Http.prototype.getLog = function() {
+Http.prototype.getLog = function () {
   return this._log;
 };
 
@@ -185,7 +184,7 @@ Http.prototype.getLog = function() {
 * Returns a clone of the current cookie jar
 * @return current cookie jar clone
 */
-Http.prototype.getCookieJar = function() {
+Http.prototype.getCookieJar = function () {
   return _.cloneDeep(this._cookieJar);
 };
 
@@ -193,7 +192,7 @@ Http.prototype.getCookieJar = function() {
 * Return a new options template instace
 * @param {object} POJO with base options
 */
-Http.prototype.optionsTemplate = function(baseOptions) {
+Http.prototype.optionsTemplate = function (baseOptions) {
   return new OptionsTemplate(baseOptions);
 };
 

--- a/http.js
+++ b/http.js
@@ -113,7 +113,7 @@ Http.prototype.request = function(method, opts, callback) {
 
   url = _.isString(opts) ? opts : opts.url;
 
-  if (_.isUndefined(url)) {
+  if (_.isUndefined(url) || !_.isString(url)) {
     throw new Error('Url is not set');
   }
 

--- a/http.js
+++ b/http.js
@@ -133,42 +133,42 @@ Http.prototype.request = function(method, opts, callback) {
 /**
 * Delegate to request's `del` method
 */
-Http.prototype.del = function (param1, param2) {
+Http.prototype.del = function (opts, callback) {
   return this.request('delete', opts, callback);
 };
 
 /**
 * Delegate to request's `get` method
 */
-Http.prototype.get = function (param1, param2) {
+Http.prototype.get = function (opts, callback) {
   return this.request('get', opts, callback);
 };
 
 /**
 * Delegate to request's `head` method
 */
-Http.prototype.head = function (param1, param2) {
+Http.prototype.head = function (opts, callback) {
   return this.request('head', opts, callback);
 };
 
 /**
 * Delegate to request's `patch` method
 */
-Http.prototype.patch = function (param1, param2) {
+Http.prototype.patch = function (opts, callback) {
   return this.request('patch', opts, callback);
 };
 
 /**
 * Delegate to request's `post` method
 */
-Http.prototype.post = function (param1, param2) {
+Http.prototype.post = function (opts, callback) {
   return this.request('post', opts, callback);
 };
 
 /**
 * Delegate to request's `put` method
 */
-Http.prototype.put = function (param1, param2) {
+Http.prototype.put = function (opts, callback) {
   return this.request('put', opts, callback);
 };
 


### PR DESCRIPTION
Remove unnecessary code duplication and moves the logic of `_buildParams` to `request` method.