### PR TITLE
timeout posible couse of 'ECONNRESET'

### DIFF
--- a/http.js
+++ b/http.js
@@ -16,7 +16,8 @@ _ = require('lodash');
 defaults = {
   follow_max: 0,
   user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like '
-  + 'Gecko) Chrome/41.0.2272.76 Safari/537.36'
+  + 'Gecko) Chrome/41.0.2272.76 Safari/537.36',
+  open_timeout: 60000
 };
 
 needle.defaults(defaults);


### PR DESCRIPTION
I notice this problem when I needed to access many different pages at the same time, this behavior cause that the scraper crash for no reason.

I went to the documentation of [needle](https://github.com/tomas/needle/blob/master/README.md) looking for some parameter that let me do a large request. To my surprise I found 'open_timeout' this property let us hang more time in the current request. This property has the original value of `10 sec`. which is too short for some pages that need more time to resolve it response.

Now, How I solve it? I've changed this value to a greater value (60 sec) 
```javascript
open_timeout: 60000 // Time in milliseconds
```
Which resolve the issue of 'ECONNRESET'. This doesn't mean that the request has take all the time, but if takes extra time to resolve it response the scraper does not crash.