### PR TITLE
Do not send cookie header if no cookies are set

### DIFF
--- a/http.js
+++ b/http.js
@@ -113,7 +113,7 @@ Http.prototype.__pushToLog = function (logEntry) {
 * @return {promise} a promise that resolves with the request's response
 */
 Http.prototype.request = function (method, opts, callback) {
-  var _this, data, url, finalOpts, makeRequest;
+  var _this, data, url, finalOpts, makeRequest, extendedCookies;
 
   _this = this;
   makeRequest = Q.defer();
@@ -128,7 +128,8 @@ Http.prototype.request = function (method, opts, callback) {
   data = opts.data || null;
 
   finalOpts = _.omit(opts, ['data', 'url']);
-  finalOpts.cookies = _.extend(this._cookieJar, finalOpts.cookies);
+  extendedCookies = _.extend(this._cookieJar, finalOpts.cookies);
+  finalOpts.cookies = _.keys(extendedCookies).length > 0 ? extendedCookies : null;
 
   needle.request(method, url, data, finalOpts, function (err, res, body) {
     _this.__interceptResponse(err, res, body, url, data, makeRequest, callback);

--- a/spec/http.spec.js
+++ b/spec/http.spec.js
@@ -227,6 +227,17 @@ describe('Http', function () {
           http.get({}, function () {});
         }).should.throw();
       });
+
+      it('should not set cookie header if cookies are empty', function (done) {
+        var newHttp;
+
+        newHttp = new Http();
+
+        newHttp.get('http://www.1.com/', function (error, res) {
+          res.req._headers.should.not.have.property('cookie');
+          done();
+        });
+      });
     });
 
     describe('#del', function () {


### PR DESCRIPTION
This PR fix needle sending an empty cookie header when receiving an empty object as cookie parameter