### PR TITLE
Add fail call to prevent done from tirggering exception

### DIFF
--- a/job.js
+++ b/job.js
@@ -324,7 +324,11 @@ Job.prototype.__runTask = function (taskSpec) {
   if (nextTaskSpec) {
     taskRunning.then(function () {
       _this.__runTask(nextTaskSpec);
-    }).done();
+    })
+    .fail(function () {
+      // Do nothing, this rejection is being handled in `__runExecutionBlock`'s Q.all call
+    })
+    .done();
   }
 
   _this.__events.emit('task:start', thisTask);


### PR DESCRIPTION
Tasks with `selfSync` option still threw exceptions instead of catching them